### PR TITLE
Add get members endpoint

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,6 +4,13 @@ FROM node:18-alpine AS builder
 # Set working directory
 WORKDIR /app
 
+RUN apk update && \
+    apk add --no-cache python3 make g++ && \
+    rm -rf /var/cache/apk/*
+
+# Set Python 3 as the default Python interpreter
+RUN ln -sf python3 /usr/bin/python
+
 # Copy package.json and package-lock.json
 COPY package*.json ./
 
@@ -22,6 +29,8 @@ COPY . .
 # Copy the built artifacts
 # COPY --from=builder /app/dist /app
 
+# Rebuild bcrypt
+RUN npm rebuild bcrypt --build-from-source
 # Expose the port
 EXPOSE 8000
 

--- a/backend/src/members/members.controller.ts
+++ b/backend/src/members/members.controller.ts
@@ -16,6 +16,13 @@ export class MembersController {
   constructor(private readonly memberService: MembersService) {}
 
   @UseGuards(AuthGuard)
+  @Get()
+  async getMembers(): Promise<GetMember[]> {
+    const members = await this.memberService.findAll();
+    return members.map((member) => this.memberService.mapMemberToMemberDto(member));
+  }
+
+  @UseGuards(AuthGuard)
   @Get(':id')
   async getMember(
     @Param('id', new ParseIntPipe()) id: number,

--- a/backend/src/members/members.service.ts
+++ b/backend/src/members/members.service.ts
@@ -11,8 +11,8 @@ export class MembersService {
     private membersRepository: Repository<Member>,
   ) {}
 
-  findAll(): Promise<Member[]> {
-    return this.membersRepository.find();
+  async findAll(): Promise<Member[]> {
+    return await this.membersRepository.find();
   }
 
   async create(member: PostMember): Promise<GetMember> {
@@ -44,6 +44,11 @@ export class MembersService {
   private static async passwordHash(password: string): Promise<string> {
     const salt = await bcrypt.genSalt(10);
     return bcrypt.hash(password, salt);
+  }
+
+  mapMemberToMemberDto(member: Member): GetMember {
+    const { password, ...memberWithoutPassword } = member;
+    return memberWithoutPassword;
   }
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3.9"
 
 services:
   mysql:
+    container_name: database
     image: mysql:8.0
     environment:
       MYSQL_ROOT_PASSWORD: root
@@ -11,7 +12,8 @@ services:
     ports:
       - "3306:3306"
 
-  nest:
+  backend:
+    container_name: backend
     build: ./backend
     environment:
       NODE_ENV: development # Set to production for production build
@@ -25,11 +27,12 @@ services:
       - mysql
 
   frontend:
+    container_name: frontend
     build: ./frontend # Builds the React app from the frontend directory
     ports:
       - "3000:3000" # Maps port 3000 of the container to port 3000 of the host
     depends_on:
-      - nest
+      - backend
     volumes:
       - ./frontend:/app
     environment:


### PR DESCRIPTION
Added get-members endpoint.

- get users are including all fields except "password field". Please comment if we need to remove more fields
- I didn't create any dto which we may need it for now I am just testing my first PR :) 
- no unit test included
- Added small script to docker file of backend which configures python as bcrypt package needs python and if I am not mistaken node:18-alpine is with out python 